### PR TITLE
Remove commons-lang3 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.18.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>net.jodah</groupId>
             <artifactId>expiringmap</artifactId>
             <version>0.5.11</version>


### PR DESCRIPTION
1. 移除重复的commons-lang3依赖声明,maven-surefire-plugin配置中有两个<argLine>标签 (pom.xml:174-175),第二个会覆盖第一个